### PR TITLE
refactor: restructure AI intake flow for bespoke user journey

### DIFF
--- a/src/ai-chat/services/interactive-chat.service.ts
+++ b/src/ai-chat/services/interactive-chat.service.ts
@@ -12,9 +12,22 @@ import { CreditService } from '../../credits/services/credit.service';
 import { AIActionType } from '../../credits/entities/credit-transaction.entity';
 import { SendMessageDto } from '../dto/chat.dto';
 import { ChatState, ChatMessage } from '../entities/chat.entity';
+
+// ─── Intake sub-steps ──────────────────────────────────────────────────────────
+// These track progress within the INFO_GATHER state.
+// The state machine only has INFO_GATHER as a DB value — sub-steps live in metadata.
+// This avoids a DB migration while giving us structured intake flow.
+type IntakeStep =
+  | 'fabric_question'   // asking if they have fabric (Path A/B fork)
+  | 'fabric_photo'      // waiting for fabric photo upload (Path A only)
+  | 'occasion'          // asking what the occasion is
+  | 'style'             // asking about style preference
+  | 'ready_to_generate' // all info collected, ready to generate designs
+
 @Injectable()
 export class InteractiveChatService {
   private readonly logger = new Logger(InteractiveChatService.name);
+
   constructor(
     private readonly chatService: ChatService,
     private readonly designWorkflowService: DesignWorkflowService,
@@ -27,19 +40,48 @@ export class InteractiveChatService {
     @InjectRepository(ChatMessage)
     private messageRepository: Repository<ChatMessage>,
   ) {}
+
+  // ─── Start chat ─────────────────────────────────────────────────────────────
+  // Called when a user opens a new chat.
+  // Sends the welcome message and sets state to WELCOME.
   async startDesignChat(userId: string) {
     const chat = await this.chatService.createChat(userId, {
       title: 'New Design Chat',
     });
+
     await this.streamChatService.createChannel(chat.id, userId);
-    const welcomeMessage = "Hey! 👋 Ready to bring your fashion idea to life?\n\nYou can:\n- Design a **custom outfit** for a special occasion, or\n- Drop a **limited-edition look** for others to buy\n\nJust upload a sketch or describe the idea, and I'll help you design it, list it, and find a Maker to bring it to life.";
+
+    // Welcome message — introduces Astra and immediately asks the fabric question
+    // which is the fork between Path A (has fabric) and Path B (has an idea)
+    const welcomeMessage = this.promptService.getPromptForState(
+      ChatState.WELCOME,
+      true,
+    );
+
     await this.streamChatService.sendAIMessage(chat.id, welcomeMessage);
     await this.chatService.sendMessage(userId, {
       chatId: chat.id,
       content: welcomeMessage,
     });
+
+    // Store the first intake sub-step in metadata so we know what we're waiting for
+    await this.chatService.updateChat(chat.id, {
+      metadata: {
+        intakeStep: 'fabric_question' as IntakeStep,
+        hasFabric: null,
+        occasion: null,
+        eventDate: null,
+        stylePreference: null,
+        fabricDescription: null,
+      },
+    });
+
     return { ...chat, welcomeMessage };
   }
+
+  // ─── Process message ─────────────────────────────────────────────────────────
+  // Entry point for every user message.
+  // Routes to the right handler based on the chat's current state.
   async processMessage(userId: string, dto: SendMessageDto) {
     let chat;
     try {
@@ -48,627 +90,859 @@ export class InteractiveChatService {
       chat = await this.startDesignChat(userId);
       dto.chatId = chat.id;
     }
-    // Mark chat as managed by interactive flow to prevent legacy auto-replies
-    // Also store model preference if provided
+
+    // Keep metadata flags up to date
     const updatedMetadata = {
       ...chat.metadata,
       managedByInteractive: true,
-      ...(dto.model && { preferredModel: dto.model })
+      ...(dto.model && { preferredModel: dto.model }),
     };
-    if (!chat.metadata?.managedByInteractive || (dto.model && dto.model !== chat.metadata?.preferredModel)) {
-      await this.chatService.updateChat(dto.chatId, { metadata: updatedMetadata });
+
+    if (
+      !chat.metadata?.managedByInteractive ||
+      (dto.model && dto.model !== chat.metadata?.preferredModel)
+    ) {
+      await this.chatService.updateChat(dto.chatId, {
+        metadata: updatedMetadata,
+      });
       chat.metadata = updatedMetadata;
     }
+
+    // Save the user's message
     const messageData: any = {
       chatId: dto.chatId,
       content: dto.content,
     };
-    
+
     if (dto.sketchData) {
       messageData.metadata = { sketchData: dto.sketchData };
     }
-    
+
     await this.chatService.sendMessage(userId, messageData);
 
-    // Action-type short-circuit handlers (chat-only flow)
+    // Sanitize before any AI processing — strips phone numbers, emails, URLs
+    const sanitizedContent = this.promptService.sanitizeUserMessage(
+      dto.content || '',
+    );
+
+    // Action-type short-circuit handlers — these are frontend-triggered actions
+    // for the design approval and minting flow (unchanged from original)
     if (dto.actionType && dto.actionType.startsWith('design:')) {
-      const action = dto.actionType;
-      try {
-        if (action === 'design:start') {
-          const chatNow = await this.chatService.getChat(userId, dto.chatId);
-          const conversationHistory = chatNow.messages.map(m => `${m.role}: ${m.content}`).join('\n');
-          if (!chatNow.metadata?.confirmRequested) {
-            // Check credits before asking to generate
-            const hasCredits = await this.creditService.hasEnoughCredits(userId, AIActionType.DESIGN_GENERATION);
-            const balance = await this.creditService.getBalance(userId);
-            if (!hasCredits) {
-              const noCreditsMsg = `You need credits to generate designs. Your current balance is ${balance} credits.\n\nPlease top up your credits to continue.`;
-              await this.streamChatService.sendAIMessage(dto.chatId, noCreditsMsg);
-              return { chatId: dto.chatId, state: 'info_gather', aiResponse: noCreditsMsg, insufficientCredits: true, creditBalance: balance };
-            }
-            const confirmMsg = `Generate 3 visual variations now? This will use 1 credit (balance: ${balance}). (yes/no)`;
-            await this.streamChatService.sendAIMessage(dto.chatId, confirmMsg);
-            await this.chatService.updateChat(dto.chatId, { state: ChatState.INFO_GATHER, metadata: { ...chatNow.metadata, confirmRequested: true } });
-            return { chatId: dto.chatId, state: 'info_gather', aiResponse: confirmMsg, awaitingConfirmation: true };
-          }
-          // If somehow confirmRequested is already true and the client still sent design:start,
-          // fall back to waiting for a plain "yes" message handled by handleInfoGathering.
-          const reply = 'Please reply "yes" to proceed or "no" to continue refining.';
-          await this.streamChatService.sendAIMessage(dto.chatId, reply);
-          return { chatId: dto.chatId, state: 'info_gather', aiResponse: reply, awaitingConfirmation: true };
-        }
-        if (action === 'design:variation') {
-          // Check and deduct credits before generating variation
-          const hasCredits = await this.creditService.hasEnoughCredits(userId, AIActionType.DESIGN_VARIATION);
-          const balance = await this.creditService.getBalance(userId);
-          if (!hasCredits) {
-            const noCreditsMsg = `You need credits to generate variations. Your current balance is ${balance} credits.\n\nPlease top up your credits to continue.`;
-            await this.streamChatService.sendAIMessage(dto.chatId, noCreditsMsg);
-            return { chatId: dto.chatId, state: 'design_preview', aiResponse: noCreditsMsg, insufficientCredits: true, creditBalance: balance };
-          }
-          
-          await this.creditService.deductCredits(userId, AIActionType.DESIGN_VARIATION, dto.chatId);
-          
-          const chatNow = await this.chatService.getChat(userId, dto.chatId);
-          const basePrompt = this.buildDesignPrompt(chatNow.messages);
-          const preferredModel = chatNow.metadata?.preferredModel;
-          
-          let result;
-          try {
-            result = await this.designWorkflowService.processDesignVariation(userId, dto.chatId, `${basePrompt} ${dto.content}`, preferredModel);
-          } catch (error) {
-            await this.creditService.refundCredits(userId, 1, 'Variation generation failed', dto.chatId);
-            throw error;
-          }
-          
-          const newBalance = await this.creditService.getBalance(userId);
-          const reply = `Generated new variations. Select one (variation_1/2/3) or refine again.\n\n💳 Credits remaining: ${newBalance}`;
-          await this.streamChatService.sendAIMessage(dto.chatId, reply);
-          return { chatId: dto.chatId, state: 'design_preview', designPreviews: result.designImages, aiResponse: reply, creditBalance: newBalance };
-        }
-        if (action === 'design:select') {
-          const sel = (dto.content || '').trim().toLowerCase();
-          const valid = ['variation_1','variation_2','variation_3'];
-          if (!valid.includes(sel)) {
-            const reply = `Please choose one of: variation_1, variation_2, variation_3.`;
-            await this.streamChatService.sendAIMessage(dto.chatId, reply);
-            return { chatId: dto.chatId, state: 'design_preview', aiResponse: reply };
-          }
-          const chatNow = await this.chatService.getChat(userId, dto.chatId);
-          await this.chatService.updateChat(dto.chatId, { metadata: { ...chatNow.metadata, selectedVariety: sel } });
-          const reply = `Selected ${sel}. Provide approval details in JSON: {"name":"...","price":150,"quantity":8,"deadline":"YYYY-MM-DD"}`;
-          await this.streamChatService.sendAIMessage(dto.chatId, reply);
-          return { chatId: dto.chatId, state: 'design_preview', aiResponse: reply };
-        }
-        if (action === 'design:approve') {
-          const chatNow = await this.chatService.getChat(userId, dto.chatId);
-          const selectedVariety = (chatNow.metadata?.selectedVariety as string) || 'variation_1';
-          let payload: any = {};
-          try { payload = JSON.parse(dto.content || '{}'); } catch {}
-          const missing: string[] = [];
-          if (!payload.name) missing.push('name');
-          if (typeof payload.price !== 'number') missing.push('price');
-          if (typeof payload.quantity !== 'number') missing.push('quantity');
-          if (!payload.deadline) missing.push('deadline');
-          if (missing.length) {
-            const reply = `Missing fields: ${missing.join(', ')}. Example: {"name":"...","price":150,"quantity":8,"deadline":"2025-12-31"}`;
-            await this.streamChatService.sendAIMessage(dto.chatId, reply);
-            return { chatId: dto.chatId, state: chatNow.state, aiResponse: reply };
-          }
-          const result = await this.designWorkflowService.approveDesign(userId, {
-            chatId: dto.chatId,
-            selectedVariety: selectedVariety as any,
-            designName: payload.name,
-            price: payload.price,
-            collectionQuantity: payload.quantity,
-            deadline: new Date(payload.deadline),
-            description: payload.description,
-          });
-          const reply = `Approved. Created DRAFT design: ${result.nft?.id}. You can "design:publish" to trigger minting, or "design:hire" to hire a maker (will require mint if still draft).`;
-          await this.streamChatService.sendAIMessage(dto.chatId, reply);
-          return { chatId: dto.chatId, state: ChatState.DESIGN_PREVIEW, aiResponse: reply, nft: result.nft };
-        }
-        if (action === 'design:publish') {
-          const reply = `Ready to mint. Please provide transaction hash via action design:mint with content {"transactionHash":"0x..."}.`;
-          await this.streamChatService.sendAIMessage(dto.chatId, reply);
-          return { chatId: dto.chatId, aiResponse: reply, web3Required: true };
-        }
-        if (action === 'design:mint') {
-          let payload: any = {};
-          try { payload = JSON.parse(dto.content || '{}'); } catch {}
-          const tx = payload.transactionHash;
-          if (!tx) {
-            const reply = `Please send transactionHash: {"transactionHash":"0x..."}`;
-            await this.streamChatService.sendAIMessage(dto.chatId, reply);
-            return { chatId: dto.chatId, aiResponse: reply };
-          }
-          const chatNow = await this.chatService.getChat(userId, dto.chatId);
-          if (!chatNow.nftId) {
-            const reply = `No approved design found. Approve first with design:approve.`;
-            await this.streamChatService.sendAIMessage(dto.chatId, reply);
-            return { chatId: dto.chatId, aiResponse: reply };
-          }
-          const nft = await this.designWorkflowService.mintAndPublishDesign(userId, chatNow.nftId, tx);
-          const reply = `Minted and published. NFT ${nft.id} is now PUBLISHED.`;
-          await this.streamChatService.sendAIMessage(dto.chatId, reply);
-          return { chatId: dto.chatId, aiResponse: reply, nft };
-        }
-        if (action === 'design:hire') {
-          let payload: any = {};
-          try { payload = JSON.parse(dto.content || '{}'); } catch {}
-          const chatNow = await this.chatService.getChat(userId, dto.chatId);
-          if (!chatNow.nftId) {
-            const reply = `No approved design found. Approve first with design:approve.`;
-            await this.streamChatService.sendAIMessage(dto.chatId, reply);
-            return { chatId: dto.chatId, aiResponse: reply };
-          }
-          const nft = await this.nftService.findById(chatNow.nftId);
-          if (nft.status === 'draft') {
-            const reply = `Design is still DRAFT. Please mint first (design:publish → design:mint).`;
-            await this.streamChatService.sendAIMessage(dto.chatId, reply);
-            return { chatId: dto.chatId, aiResponse: reply };
-          }
-          const required = ['quantity','deadlineDate','productTimeline','budgetRange','shippingRegion','fabricSource','skillKeywords','experienceLevel'];
-          const missing = required.filter(f => payload[f] === undefined);
-          if (missing.length) {
-            const reply = `Missing fields: ${missing.join(', ')}. Example: {"quantity":8,"deadlineDate":"2025-12-31","productTimeline":"3-4 weeks","budgetRange":{"min":800,"max":2500},"shippingRegion":"United States","fabricSource":"Premium cotton","skillKeywords":["sewing","pattern-making"],"experienceLevel":"advanced","requirements":"High quality production"}`;
-            await this.streamChatService.sendAIMessage(dto.chatId, reply);
-            return { chatId: dto.chatId, aiResponse: reply };
-          }
-          const createJobDto: any = {
-            title: `Hire Maker for ${nft.name}`,
-            description: payload.requirements,
-            requirements: `Quantity: ${payload.quantity}\nDeadline: ${payload.deadlineDate}\nTimeline: ${payload.productTimeline}\nBudget Range: $${payload.budgetRange?.min}-$${payload.budgetRange?.max}\nShipping: ${payload.shippingRegion}\nFabric Source: ${payload.fabricSource}\nExperience Level: ${payload.experienceLevel}\nSkills: ${(payload.skillKeywords||[]).join(', ')}`,
-            budget: payload.budgetRange?.max,
-            currency: 'USD',
-            priority: 'medium',
-            deadline: new Date(payload.deadlineDate).toISOString(),
-            tags: ['maker-hiring','production', payload.experienceLevel, `budget-${payload.budgetRange?.min}-${payload.budgetRange?.max}`, ...(payload.skillKeywords||[])],
-            referenceImages: [nft.imageUrl],
-            chatId: dto.chatId,
-            designId: nft.id,
-          };
-          const job = await this.jobService.createJob(createJobDto, userId);
-          const reply = `Maker hiring request created. Job ${job.id} is now visible to makers.`;
-          await this.streamChatService.sendAIMessage(dto.chatId, reply);
-          return { chatId: dto.chatId, aiResponse: reply, job };
-        }
-      } catch (err) {
-        const msg = `Sorry, something went wrong: ${err?.message || 'unknown error'}`;
-        await this.streamChatService.sendAIMessage(dto.chatId, msg);
-        return { chatId: dto.chatId, aiResponse: msg };
-      }
+      return this.handleDesignAction(userId, dto, chat);
     }
-    
-    // Sync user message to database via Stream Chat
-    await this.streamChatService.syncUserMessageToDatabase(dto.chatId, dto.content, userId);
+
+    await this.streamChatService.syncUserMessageToDatabase(
+      dto.chatId,
+      dto.content,
+      userId,
+    );
+
+    // Route by state
     switch (chat.state) {
       case ChatState.WELCOME:
-        return this.handleInitialDesignInput(userId, dto.chatId, dto.content);
       case ChatState.INTENT:
-        return this.handleIntentResponse(userId, dto.chatId, dto.content);
       case ChatState.INFO_GATHER:
-        return this.handleInfoGathering(userId, dto.chatId, dto.content, chat.metadata);
-      case ChatState.DESIGN_PREVIEW:
-        return this.handleDesignSelection(userId, dto.chatId, dto.content);
-      default:
-        return this.handleGeneralMessage(userId, dto.chatId, dto.content);
-    }
-  }
-  private async handleInitialDesignInput(userId: string, chatId: string, content: string) {
-    const chat = await this.chatService.getChat(userId, chatId);
-    const conversationHistory = chat.messages.map(msg => `${msg.role}: ${msg.content}`).join('\n');
-    const aiResponse = await this.generateContextualResponse(content, conversationHistory, 'welcome');
-    const nextState = await this.determineConversationState(aiResponse, conversationHistory + `\nuser: ${content}\nassistant: ${aiResponse}`);
-    if (nextState !== 'welcome') {
-      await this.chatService.updateChat(chatId, { state: nextState as ChatState });
-    }
-    await this.streamChatService.sendAIMessage(chatId, aiResponse);
-    return { chatId, state: nextState, aiResponse, designPreviews: undefined };
-  }
-  private async generateContextualResponse(userMessage: string, conversationHistory: string, currentState: string): Promise<string> {
-    const systemPrompt = this.promptService.getSystemPrompt();
-    const contextPrompt = `${systemPrompt}
-Current conversation state: ${currentState}
-Conversation so far:
-${conversationHistory}
-User just said: "${userMessage}"
-Respond naturally and guide the conversation toward fashion design. Your goals:
-1. If greeting/casual: Be friendly, ask what they'd like to design
-2. If showing interest: Ask if it's for them or to sell (A/B question)
-3. If they chose A/B: Gather specifics (event, style, colors, etc.)
-4. Collect as many details as possible before suggesting design generation
-Be conversational, smooth, and BRIEF. Keep responses short and focused. Don't repeat questions already answered.`;
-    try {
-      const response = await this.openaiService.generateResponse(contextPrompt);
-      return response.trim();
-    } catch (error) {
-      return "Hey there! 👋 What kind of fashion design are you thinking about creating?";
-    }
-  }
-  private async determineConversationState(aiResponse: string, fullConversation: string): Promise<string> {
-    try {
-      const statePrompt = `Based on this conversation, what state should we be in?
-Conversation:
-${fullConversation}
-States:
-- welcome: Still greeting/getting started
-- intent: Asked about personal vs commercial (A/B question)
-- info_gather: Collecting design details
-- ready_to_generate: Has enough info to create design
-Reply with ONLY the state name.`;
-      const response = await this.openaiService.generateResponse(statePrompt);
-      const state = response.trim().toLowerCase();
-      if (state.includes('intent')) return 'intent';
-      if (state.includes('info') || state.includes('gather')) return 'info_gather';
-      if (state.includes('ready') || state.includes('generate')) return 'info_gather';
-      return 'welcome';
-    } catch (error) {
-      return 'welcome';
-    }
-  }
-  private async handleIntentResponse(userId: string, chatId: string, content: string) {
-    const chat = await this.chatService.getChat(userId, chatId);
-    const conversationHistory = chat.messages.map(msg => `${msg.role}: ${msg.content}`).join('\n');
-    const aiResponse = await this.generateContextualResponse(content, conversationHistory, 'intent');
-    const nextState = await this.determineConversationState(aiResponse, conversationHistory + `\nuser: ${content}\nassistant: ${aiResponse}`);
-    if (nextState !== 'intent') {
-      await this.chatService.updateChat(chatId, { 
-        state: nextState as ChatState,
-        metadata: { ...chat.metadata, lastUserInput: content }
-      });
-    }
-    await this.streamChatService.sendAIMessage(chatId, aiResponse);
-    return { chatId, state: nextState, aiResponse, designPreviews: undefined };
-  }
-  private async handleInfoGathering(userId: string, chatId: string, content: string, metadata: any) {
-    const chat = await this.chatService.getChat(userId, chatId);
-    const conversationHistory = chat.messages.map(msg => `${msg.role}: ${msg.content}`).join('\n');
-    // Cooldown: if we already generated 3 in the last 2 minutes, don't regenerate
-    const lastDone = chat.metadata?.lastGenerationCompletedAt ? new Date(chat.metadata.lastGenerationCompletedAt).getTime() : 0;
-    const recent = lastDone && (Date.now() - lastDone < 2 * 60 * 1000);
-    // Confirmation gate: always ask before generating
-    const confirmRequested = !!chat.metadata?.confirmRequested;
-    if (!confirmRequested) {
-      // Check credits before asking to generate
-      const hasCredits = await this.creditService.hasEnoughCredits(userId, AIActionType.DESIGN_GENERATION);
-      const balance = await this.creditService.getBalance(userId);
-      if (!hasCredits) {
-        const noCreditsMsg = `You need credits to generate designs. Your current balance is ${balance} credits.\n\nPlease top up your credits to continue.`;
-        await this.streamChatService.sendAIMessage(chatId, noCreditsMsg);
-        return { chatId, state: 'info_gather', aiResponse: noCreditsMsg, insufficientCredits: true, creditBalance: balance };
-      }
-      const confirmMsg = `I can generate 3 visual variations for your design now. This will use 1 credit (balance: ${balance}). Would you like me to proceed? (yes/no)`;
-      await this.streamChatService.sendAIMessage(chatId, confirmMsg);
-      await this.chatService.updateChat(chatId, { metadata: { ...chat.metadata, confirmRequested: true } });
-      return { chatId, state: 'info_gather', aiResponse: confirmMsg, awaitingConfirmation: true };
-    }
-    // If user explicitly confirmed, proceed immediately without re-checking intent
-    const isConfirming = await this.isUserConfirming(content, conversationHistory);
-    if (isConfirming && recent && (chat.designPreviews?.length || 0) >= 3) {
-      const msg = "I already generated 3 variations. Please pick one (variation_1/2/3) or tell me what to tweak.";
-      await this.streamChatService.sendAIMessage(chatId, msg);
-      return { chatId, state: 'info_gather', aiResponse: msg };
-    }
-    // If not confirming and a generation is already in progress, ask user to wait
-    if (!isConfirming && chat.metadata?.generating === true) {
-      const waitMsg = 'Working on your variations… one moment please.';
-      await this.streamChatService.sendAIMessage(chatId, waitMsg);
-      return { chatId, state: 'info_gather', aiResponse: waitMsg, awaitingConfirmation: false };
-    }
-    if (isConfirming) {
-      // Deduct credits before generation
-      try {
-        await this.creditService.deductCredits(userId, AIActionType.DESIGN_GENERATION, chatId);
-      } catch (error) {
-        const balance = await this.creditService.getBalance(userId);
-        const noCreditsMsg = `Insufficient credits to generate designs. Your current balance is ${balance} credits.\n\nPlease top up your credits to continue.`;
-        await this.streamChatService.sendAIMessage(chatId, noCreditsMsg);
-        return { chatId, state: 'info_gather', aiResponse: noCreditsMsg, insufficientCredits: true, creditBalance: balance };
-      }
+        // All intake states handled by the structured intake flow
+        return this.handleIntake(userId, dto.chatId, sanitizedContent, dto.sketchData);
 
-      const generatingMessage = "Perfect! Let me generate a visual design for you... This will take a moment.";
-      await this.streamChatService.sendAIMessage(chatId, generatingMessage);
-      const designPrompt = this.buildDesignPrompt(chat.messages);
-      const sketchBase64 = this.extractSketchFromMessages(chat.messages);
-      const preferredModel = chat.metadata?.preferredModel;
-      
-      let result;
-      try {
-        result = await this.designWorkflowService.processDesignRequest(userId, {
-          prompt: designPrompt,
-          fabricImageBase64: sketchBase64,
-          model: preferredModel,
-          // Ensure centralized guard can use the chat context
-          ...( { chatId } as any ),
-        } as any);
-      } catch (error) {
-        // Refund credits if generation fails
-        await this.creditService.refundCredits(userId, 1, 'Design generation failed', chatId);
-        throw error;
-      }
-      
-      const images = result.designImages || [];
-      const newBalance = await this.creditService.getBalance(userId);
-      const completionMessage = `Here are your design variations! 🎨\n\n${images.map((url, i) => `**Variation ${i + 1}**: ${url || 'Design created'}`).join('\n')}\n\nWhich one do you like best?\n\n💳 Credits remaining: ${newBalance}`;
-      await this.streamChatService.sendAIMessage(chatId, completionMessage);
-      await this.chatService.updateChat(chatId, { state: ChatState.DESIGN_PREVIEW, metadata: { ...chat.metadata, confirmRequested: false, generating: false, lastGenerationCompletedAt: new Date().toISOString() } });
-      return { 
-        chatId, 
-        state: 'design_preview',
-        designPreviews: images,
-        job: result?.job,
-        nft: result?.nft,
-        aiResponse: completionMessage,
-        creditBalance: newBalance,
-      };
+      case ChatState.DESIGN_PREVIEW:
+        return this.handleDesignSelection(userId, dto.chatId, sanitizedContent);
+
+      default:
+        return this.handleGeneralMessage(userId, dto.chatId, sanitizedContent);
     }
-    // Otherwise, continue gathering info conversationally
-    const aiResponse = await this.generateContextualResponse(content, conversationHistory, 'info_gather');
-    await this.streamChatService.sendAIMessage(chatId, aiResponse);
-    return { chatId, state: 'info_gather', aiResponse, designPreviews: undefined };
   }
-  private async handleDesignSelection(userId: string, chatId: string, content: string) {
+
+  // ─── Intake flow ──────────────────────────────────────────────────────────────
+  // Handles all intake states: WELCOME, INTENT, INFO_GATHER
+  // Uses intakeStep in metadata to track progress through sub-steps.
+  // One question at a time — never asks for more than one thing.
+  private async handleIntake(
+    userId: string,
+    chatId: string,
+    content: string,
+    sketchData?: string,
+  ) {
     const chat = await this.chatService.getChat(userId, chatId);
-    const conversationHistory = chat.messages.map(msg => `${msg.role}: ${msg.content}`).join('\n');
-    
-    // Check if we're waiting for confirmation and user is providing more details
-    if (chat.metadata?.confirmVariationRequested) {
-      const confirm = await this.isUserConfirming(content, conversationHistory);
-      if (confirm) {
-        // Deduct credits before generating variation
-        try {
-          await this.creditService.deductCredits(userId, AIActionType.DESIGN_VARIATION, chatId);
-        } catch (error) {
-          const balance = await this.creditService.getBalance(userId);
-          const noCreditsMsg = `Insufficient credits to generate variations. Your current balance is ${balance} credits.\n\nPlease top up your credits to continue.`;
-          await this.streamChatService.sendAIMessage(chatId, noCreditsMsg);
-          return { chatId, state: 'design_preview', aiResponse: noCreditsMsg, insufficientCredits: true, creditBalance: balance };
+    const metadata = chat.metadata || {};
+    const step: IntakeStep = metadata.intakeStep || 'fabric_question';
+
+    this.logger.log(`Intake step: ${step} | chatId: ${chatId}`);
+
+    switch (step) {
+
+      // ── Step 1: fabric question ──────────────────────────────────────────────
+      // User answers whether they have fabric or not.
+      // This is the fork between Path A and Path B.
+      case 'fabric_question': {
+        const hasFabric = await this.detectFabricAnswer(content);
+
+        if (hasFabric === null) {
+          // Unclear answer — ask again clearly
+          const clarify =
+            "Just to check — do you have a fabric you'd like to use, or are you starting from an idea? Tap one of the options below.";
+          await this.streamChatService.sendAIMessage(chatId, clarify);
+          return {
+            chatId,
+            state: chat.state,
+            aiResponse: clarify,
+            quickButtons: ['Yes, I have fabric', 'No, just an idea'],
+          };
         }
 
-        const generatingMessage = "Generating another variation for you...";
-        await this.streamChatService.sendAIMessage(chatId, generatingMessage);
-        const designPrompt = this.buildDesignPrompt(chat.messages);
-        const sketchBase64 = this.extractSketchFromMessages(chat.messages);
-        
-        // Get the user's modification request from metadata and combine with current input
-        const pendingMod = chat.metadata?.pendingModification || '';
-        const userModification = pendingMod + (pendingMod ? ' ' + content : content);
-        const enhancedPrompt = `${designPrompt} - ${userModification}`;
-        const preferredModel = chat.metadata?.preferredModel;
+        if (hasFabric) {
+          // Path A — they have fabric. Ask for a photo.
+          const askPhoto =
+            "Great! Upload a photo of your fabric so I can design around its colour and texture.";
+          await this.streamChatService.sendAIMessage(chatId, askPhoto);
+          await this.chatService.updateChat(chatId, {
+            state: ChatState.INFO_GATHER,
+            metadata: {
+              ...metadata,
+              hasFabric: true,
+              intakeStep: 'fabric_photo' as IntakeStep,
+            },
+          });
+          return { chatId, state: 'info_gather', aiResponse: askPhoto };
+        } else {
+          // Path B — no fabric. Skip photo, go straight to occasion.
+          const askOccasion =
+            "No problem at all! Tell me about the occasion — what's the event, and when is it?";
+          await this.streamChatService.sendAIMessage(chatId, askOccasion);
+          await this.chatService.updateChat(chatId, {
+            state: ChatState.INFO_GATHER,
+            metadata: {
+              ...metadata,
+              hasFabric: false,
+              intakeStep: 'occasion' as IntakeStep,
+            },
+          });
+          return { chatId, state: 'info_gather', aiResponse: askOccasion };
+        }
+      }
+
+      // ── Step 2a: fabric photo (Path A only) ────────────────────────────────
+      // Wait for an image upload. If no image yet, keep asking.
+      case 'fabric_photo': {
+        const hasPhoto = !!sketchData || await this.detectImageInMessage(content);
+
+        if (!hasPhoto) {
+          const nudge =
+            "I need a photo of the fabric to design around it — tap the photo icon to upload one, or describe the fabric if you're not able to upload right now.";
+          await this.streamChatService.sendAIMessage(chatId, nudge);
+          return { chatId, state: 'info_gather', aiResponse: nudge };
+        }
+
+        // Photo received — extract description and move to occasion
+        const fabricDescription = await this.describeFabricFromPhoto(
+          content,
+          sketchData,
+        );
+
+        const askOccasion = `Lovely fabric! Tell me about the occasion — what's the event and when is it?`;
+        await this.streamChatService.sendAIMessage(chatId, askOccasion);
+        await this.chatService.updateChat(chatId, {
+          metadata: {
+            ...metadata,
+            fabricDescription,
+            intakeStep: 'occasion' as IntakeStep,
+          },
+        });
+        return { chatId, state: 'info_gather', aiResponse: askOccasion };
+      }
+
+      // ── Step 2b / 3: occasion ───────────────────────────────────────────────
+      // Collect the occasion type, role, and event date from one message.
+      case 'occasion': {
+        const occasionInfo = await this.extractOccasionInfo(content);
+
+        if (!occasionInfo.occasion) {
+          const clarify =
+            "Could you tell me a bit more about the event? For example: a wedding, prom, birthday dinner — and when is it?";
+          await this.streamChatService.sendAIMessage(chatId, clarify);
+          return { chatId, state: 'info_gather', aiResponse: clarify };
+        }
+
+        const askStyle = this.buildStyleQuestion(
+          occasionInfo.occasion,
+          metadata.fabricDescription,
+        );
+
+        await this.streamChatService.sendAIMessage(chatId, askStyle);
+        await this.chatService.updateChat(chatId, {
+          metadata: {
+            ...metadata,
+            occasion: occasionInfo.occasion,
+            eventDate: occasionInfo.eventDate,
+            occasionRole: occasionInfo.role,
+            intakeStep: 'style' as IntakeStep,
+          },
+        });
+        return {
+          chatId,
+          state: 'info_gather',
+          aiResponse: askStyle,
+          quickButtons: ['Fitted & Structured', 'Flowing & Relaxed', 'Surprise me'],
+        };
+      }
+
+      // ── Step 4: style preference ────────────────────────────────────────────
+      // Collect style direction — then we have everything to generate designs.
+      case 'style': {
+        const stylePreference = content;
+
+        // All info collected — ready to generate
+        const readyMsg =
+          `Perfect — I have everything I need. Ready to generate 3 designs for your ${metadata.occasion || 'occasion'}? This uses 1 credit.`;
+
+        await this.streamChatService.sendAIMessage(chatId, readyMsg);
+        await this.chatService.updateChat(chatId, {
+          metadata: {
+            ...metadata,
+            stylePreference,
+            intakeStep: 'ready_to_generate' as IntakeStep,
+            confirmRequested: true,
+          },
+        });
+        return {
+          chatId,
+          state: 'info_gather',
+          aiResponse: readyMsg,
+          awaitingConfirmation: true,
+          quickButtons: ['Yes, generate my designs', 'No, let me change something'],
+        };
+      }
+
+      // ── Step 5: ready to generate ───────────────────────────────────────────
+      // User confirmed — check credits and generate (or stub for week 1).
+      case 'ready_to_generate': {
+        const isConfirming = await this.isUserConfirming(content);
+
+        if (!isConfirming) {
+          // User wants to change something — go back to style question
+          const goBack =
+            "No problem — what would you like to change? You can describe the style, occasion, or anything else.";
+          await this.streamChatService.sendAIMessage(chatId, goBack);
+          await this.chatService.updateChat(chatId, {
+            metadata: {
+              ...metadata,
+              intakeStep: 'style' as IntakeStep,
+              confirmRequested: false,
+            },
+          });
+          return { chatId, state: 'info_gather', aiResponse: goBack };
+        }
+
+        // Check credits
+        const hasCredits = await this.creditService.hasEnoughCredits(
+          userId,
+          AIActionType.DESIGN_GENERATION,
+        );
+        const balance = await this.creditService.getBalance(userId);
+
+        if (!hasCredits) {
+          const noCredits = `You need credits to generate designs. Your current balance is ${balance}. Please top up to continue.`;
+          await this.streamChatService.sendAIMessage(chatId, noCredits);
+          return {
+            chatId,
+            state: 'info_gather',
+            aiResponse: noCredits,
+            insufficientCredits: true,
+            creditBalance: balance,
+          };
+        }
+
+        // Deduct credits
+        await this.creditService.deductCredits(
+          userId,
+          AIActionType.DESIGN_GENERATION,
+          chatId,
+        );
+
+        // Generating message
+        const generatingMsg =
+          `On it! Generating 3 designs for your ${metadata.occasion || 'occasion'} — this takes a moment ✨`;
+        await this.streamChatService.sendAIMessage(chatId, generatingMsg);
+
+        // Build a structured prompt from everything collected
+        const designPrompt = this.buildStructuredDesignPrompt(metadata);
+        const fabricImageBase64 = this.extractSketchFromMessages(chat.messages);
 
         let result;
         try {
-          result = await this.designWorkflowService.processDesignVariation(userId, chatId, enhancedPrompt, preferredModel);
+          // ── WEEK 1: stub ───────────────────────────────────────────────────
+          // Real gpt-image-2 integration comes in week 2.
+          // For now, return placeholder images so the full conversation flow
+          // can be tested end-to-end without the image API.
+          // Replace this block in week 2 with the real call:
+          //
+          //   result = await this.designWorkflowService.processDesignRequest(userId, {
+          //     prompt: designPrompt,
+          //     fabricImageBase64,
+          //     model: chat.metadata?.preferredModel,
+          //     chatId,
+          //   });
+          //
+          result = {
+            designImages: [
+              'https://placehold.co/600x800?text=Design+1',
+              'https://placehold.co/600x800?text=Design+2',
+              'https://placehold.co/600x800?text=Design+3',
+            ],
+          };
+          // ── END WEEK 1 STUB ────────────────────────────────────────────────
         } catch (error) {
-          // Refund credits if variation generation fails
-          await this.creditService.refundCredits(userId, 1, 'Variation generation failed', chatId);
+          // Refund credits if generation fails
+          await this.creditService.refundCredits(
+            userId,
+            1,
+            'Design generation failed',
+            chatId,
+          );
           throw error;
         }
-        
+
+        const images = result.designImages || [];
         const newBalance = await this.creditService.getBalance(userId);
-        const completionMessage = `Here's a new set of variations! Do you like one of these better?\n\n💳 Credits remaining: ${newBalance}`;
-        await this.streamChatService.sendAIMessage(chatId, completionMessage);
-        await this.chatService.updateChat(chatId, { 
-          metadata: { 
-            ...chat.metadata, 
+
+        const completionMsg =
+          `Here are your 3 designs for your ${metadata.occasion || 'occasion'} 🎨 Which one feels most like you?\n\n` +
+          images.map((url, i) => `**Design ${i + 1}:** ${url}`).join('\n') +
+          `\n\n💳 Credits remaining: ${newBalance}`;
+
+        await this.streamChatService.sendAIMessage(chatId, completionMsg);
+        await this.chatService.updateChat(chatId, {
+          state: ChatState.DESIGN_PREVIEW,
+          metadata: {
+            ...metadata,
+            confirmRequested: false,
+            generating: false,
+            lastGenerationCompletedAt: new Date().toISOString(),
+          },
+        });
+
+        return {
+          chatId,
+          state: 'design_preview',
+          designPreviews: images,
+          aiResponse: completionMsg,
+          creditBalance: newBalance,
+        };
+      }
+
+      default: {
+        // Fallback — shouldn't be reached but handle gracefully
+        return this.handleGeneralMessage(userId, chatId, content);
+      }
+    }
+  }
+
+  // ─── Design selection ─────────────────────────────────────────────────────
+  // Handles the DESIGN_PREVIEW state — user picks a design or requests changes.
+  private async handleDesignSelection(
+    userId: string,
+    chatId: string,
+    content: string,
+  ) {
+    const chat = await this.chatService.getChat(userId, chatId);
+    const conversationHistory = chat.messages
+      .map((m) => `${m.role}: ${m.content}`)
+      .join('\n');
+
+    // Check if waiting for variation confirmation
+    if (chat.metadata?.confirmVariationRequested) {
+      const confirm = await this.isUserConfirming(content);
+      if (confirm) {
+        const hasCredits = await this.creditService.hasEnoughCredits(
+          userId,
+          AIActionType.DESIGN_VARIATION,
+        );
+        const balance = await this.creditService.getBalance(userId);
+        if (!hasCredits) {
+          const noCredits = `You need credits to generate variations. Balance: ${balance}.`;
+          await this.streamChatService.sendAIMessage(chatId, noCredits);
+          return {
+            chatId,
+            state: 'design_preview',
+            aiResponse: noCredits,
+            insufficientCredits: true,
+            creditBalance: balance,
+          };
+        }
+        await this.creditService.deductCredits(
+          userId,
+          AIActionType.DESIGN_VARIATION,
+          chatId,
+        );
+        const generatingMsg = 'Generating new variations for you...';
+        await this.streamChatService.sendAIMessage(chatId, generatingMsg);
+
+        const designPrompt = this.buildStructuredDesignPrompt(chat.metadata);
+        const pendingMod = chat.metadata?.pendingModification || '';
+        const enhancedPrompt = `${designPrompt} ${pendingMod} ${content}`.trim();
+
+        let result;
+        try {
+          result = await this.designWorkflowService.processDesignVariation(
+            userId,
+            chatId,
+            enhancedPrompt,
+            chat.metadata?.preferredModel,
+          );
+        } catch (error) {
+          await this.creditService.refundCredits(
+            userId,
+            1,
+            'Variation generation failed',
+            chatId,
+          );
+          throw error;
+        }
+
+        const newBalance = await this.creditService.getBalance(userId);
+        const reply = `Here are your new variations! Which one do you prefer?\n\n💳 Credits remaining: ${newBalance}`;
+        await this.streamChatService.sendAIMessage(chatId, reply);
+        await this.chatService.updateChat(chatId, {
+          metadata: {
+            ...chat.metadata,
             confirmVariationRequested: false,
             pendingModification: null,
-            lastGenerationCompletedAt: new Date().toISOString()
-          } 
+            lastGenerationCompletedAt: new Date().toISOString(),
+          },
         });
-        return { 
-          chatId, 
+        return {
+          chatId,
           state: 'design_preview',
-          aiResponse: completionMessage,
+          aiResponse: reply,
           creditBalance: newBalance,
         };
       } else {
-        // User is providing more details, update the pending modification
         const pendingMod = chat.metadata?.pendingModification || '';
-        const updatedModification = pendingMod + (pendingMod ? ' ' + content : content);
-        await this.chatService.updateChat(chatId, { 
-          metadata: { 
-            ...chat.metadata, 
-            pendingModification: updatedModification
-          } 
+        await this.chatService.updateChat(chatId, {
+          metadata: {
+            ...chat.metadata,
+            pendingModification: `${pendingMod} ${content}`.trim(),
+          },
         });
-        const msg = "Got it! Any other details you'd like to add, or should I proceed with the design? (yes/no)";
+        const msg = "Got it! Anything else to add, or shall I generate with those changes? (yes/no)";
         await this.streamChatService.sendAIMessage(chatId, msg);
         return { chatId, state: 'design_preview', aiResponse: msg };
       }
-    }
-    
-    // If we already have 3 previews recently, block further generation until selection or tweak
-    const lastDone = chat.metadata?.lastGenerationCompletedAt ? new Date(chat.metadata.lastGenerationCompletedAt).getTime() : 0;
-    const recent = lastDone && (Date.now() - lastDone < 2 * 60 * 1000);
-    const hasThree = (chat.designPreviews?.length || 0) >= 3;
-    const wantsNewVariation = await this.wantsNewVariation(content);
-    if (wantsNewVariation) {
-      if (recent && hasThree) {
-        const msg = "I already generated 3 variations. Please pick one (variation_1/2/3) or tell me what to tweak.";
-        await this.streamChatService.sendAIMessage(chatId, msg);
-        return { chatId, state: 'design_preview', aiResponse: msg };
-      }
-      // Check credits before asking to generate variation
-      const hasCredits = await this.creditService.hasEnoughCredits(userId, AIActionType.DESIGN_VARIATION);
-      const balance = await this.creditService.getBalance(userId);
-      if (!hasCredits) {
-        const noCreditsMsg = `You need credits to generate variations. Your current balance is ${balance} credits.\n\nPlease top up your credits to continue.`;
-        await this.streamChatService.sendAIMessage(chatId, noCreditsMsg);
-        return { chatId, state: 'design_preview', aiResponse: noCreditsMsg, insufficientCredits: true, creditBalance: balance };
-      }
-      // Confirmation gate before creating another variation
-      const ask = `I can generate another variation now. This will use 1 credit (balance: ${balance}). Would you like me to proceed? (yes/no)`;
-      await this.streamChatService.sendAIMessage(chatId, ask);
-      await this.chatService.updateChat(chatId, { 
-        metadata: { 
-          ...chat.metadata, 
-          confirmVariationRequested: true,
-          pendingModification: content // Store the user's modification request
-        } 
-      });
-      return { chatId, state: 'design_preview', aiResponse: ask };
-    }
-    
-    // Check if user is selecting/approving a specific design
-    const designSelection = await this.detectDesignSelection(content);
-    if (designSelection) {
-      // Ask for minting confirmation
-      const mintingConfirmationMsg = `Perfect! You've selected ${designSelection}. Would you like to bring this to life? This will make it available in your "My Designs" collection. (yes/no)`;
-      await this.streamChatService.sendAIMessage(chatId, mintingConfirmationMsg);
-      await this.chatService.updateChat(chatId, { 
-        metadata: { 
-          ...chat.metadata, 
-          selectedDesign: designSelection,
-          awaitingMintConfirmation: true
-        } 
-      });
-      return { chatId, state: 'design_preview', aiResponse: mintingConfirmationMsg };
     }
 
-    // Check if user is confirming minting
+    // Check if user wants a new variation
+    const wantsVariation = await this.wantsNewVariation(content);
+    if (wantsVariation) {
+      const hasCredits = await this.creditService.hasEnoughCredits(
+        userId,
+        AIActionType.DESIGN_VARIATION,
+      );
+      const balance = await this.creditService.getBalance(userId);
+      if (!hasCredits) {
+        const noCredits = `You need credits to generate variations. Balance: ${balance}.`;
+        await this.streamChatService.sendAIMessage(chatId, noCredits);
+        return {
+          chatId,
+          state: 'design_preview',
+          aiResponse: noCredits,
+          insufficientCredits: true,
+          creditBalance: balance,
+        };
+      }
+      const ask = `I can generate new variations incorporating those changes. This uses 1 credit (balance: ${balance}). Shall I go ahead?`;
+      await this.streamChatService.sendAIMessage(chatId, ask);
+      await this.chatService.updateChat(chatId, {
+        metadata: {
+          ...chat.metadata,
+          confirmVariationRequested: true,
+          pendingModification: content,
+        },
+      });
+      return {
+        chatId,
+        state: 'design_preview',
+        aiResponse: ask,
+        quickButtons: ['Yes, generate', 'No, let me describe more'],
+      };
+    }
+
+    // Check if user is selecting a specific design
+    const designSelection = await this.detectDesignSelection(content);
+    if (designSelection) {
+      const confirmMsg = `Great choice! You've selected ${designSelection}. Want to move forward with this design and find a tailor to make it?`;
+      await this.streamChatService.sendAIMessage(chatId, confirmMsg);
+      await this.chatService.updateChat(chatId, {
+        metadata: {
+          ...chat.metadata,
+          selectedDesign: designSelection,
+          awaitingMintConfirmation: true,
+        },
+      });
+      return {
+        chatId,
+        state: 'design_preview',
+        aiResponse: confirmMsg,
+        quickButtons: ['Yes, find me a tailor', 'No, show me more options'],
+      };
+    }
+
+    // Check if user is confirming design and moving to tailor
     if (chat.metadata?.awaitingMintConfirmation) {
-      const confirmMinting = await this.isUserConfirming(content, conversationHistory);
+      const confirmMinting = await this.isUserConfirming(content);
       if (confirmMinting) {
-        const handoffMsg = `Great! I'll prepare your design for minting. The frontend will now handle the payment and minting process. Once minted, your design will appear in "My Designs" collection.`;
+        const handoffMsg = `Let's find you a tailor! I'm preparing your design brief now.`;
         await this.streamChatService.sendAIMessage(chatId, handoffMsg);
-        await this.chatService.updateChat(chatId, { 
+        await this.chatService.updateChat(chatId, {
           state: ChatState.DESIGN_APPROVED,
-          metadata: { 
-            ...chat.metadata, 
+          metadata: {
+            ...chat.metadata,
             awaitingMintConfirmation: false,
             readyForMinting: true,
-            selectedVariation: chat.metadata?.selectedDesign
-          } 
+            selectedVariation: chat.metadata?.selectedDesign,
+          },
         });
         return { chatId, state: 'design_approved', aiResponse: handoffMsg };
       } else {
-        const cancelMsg = `No problem! You can continue browsing the variations or request changes. Which design do you prefer?`;
+        const cancelMsg = `No problem! Take your time — which of the three designs do you prefer?`;
         await this.streamChatService.sendAIMessage(chatId, cancelMsg);
-        await this.chatService.updateChat(chatId, { 
-          metadata: { 
-            ...chat.metadata, 
+        await this.chatService.updateChat(chatId, {
+          metadata: {
+            ...chat.metadata,
             awaitingMintConfirmation: false,
-            selectedDesign: null
-          } 
+            selectedDesign: null,
+          },
         });
         return { chatId, state: 'design_preview', aiResponse: cancelMsg };
       }
     }
 
-    // Handle other cases (general comments)
-    const aiResponse = await this.generateContextualResponse(content, conversationHistory, 'design_preview');
+    // General comment on the designs
+    const aiResponse = await this.generateContextualResponse(
+      content,
+      conversationHistory,
+      'design_preview',
+    );
     await this.streamChatService.sendAIMessage(chatId, aiResponse);
-    return { chatId, state: 'design_preview', aiResponse, designPreviews: undefined };
+    return { chatId, state: 'design_preview', aiResponse };
   }
-  private async handleGeneralMessage(userId: string, chatId: string, content: string) {
+
+  // ─── General message handler ───────────────────────────────────────────────
+  // Fallback for any state not explicitly handled above.
+  private async handleGeneralMessage(
+    userId: string,
+    chatId: string,
+    content: string,
+  ) {
     const chat = await this.chatService.getChat(userId, chatId);
-    const conversationHistory = chat.messages.map(msg => `${msg.role}: ${msg.content}`).join('\n');
-    const aiResponse = await this.generateContextualResponse(content, conversationHistory, 'general');
+    const conversationHistory = chat.messages
+      .map((m) => `${m.role}: ${m.content}`)
+      .join('\n');
+    const aiResponse = await this.generateContextualResponse(
+      content,
+      conversationHistory,
+      'general',
+    );
     await this.streamChatService.sendAIMessage(chatId, aiResponse);
-    return { chatId, state: chat.state, aiResponse, designPreviews: undefined };
+    return { chatId, state: chat.state, aiResponse };
   }
-  private async shouldGenerateDesign(conversationHistory: string): Promise<boolean> {
+
+  // ─── Design action handler ─────────────────────────────────────────────────
+  // Handles frontend-triggered design:* actions (approve, mint, hire etc.)
+  // Largely unchanged from original — these are the post-design actions.
+  private async handleDesignAction(userId: string, dto: SendMessageDto, chat: any) {
+    const action = dto.actionType;
     try {
-      const response = await this.openaiService.generateChatResponse([
-        { role: 'system', content: 'Decide if we should generate design variations NOW. Consider both detail sufficiency and user intent for the AI to proceed. Reply only "yes" or "no".' },
-        { role: 'user', content: `Conversation so far:\n${conversationHistory}\n\nShould we generate variations now?` }
-      ]);
-      return /^(yes|y)/i.test(response.trim());
-    } catch (error) {
-      return false;
-    }
-  }
-  private async isUserConfirming(content: string, conversationHistory?: string): Promise<boolean> {
-    try {
-      const prompt = `Analyze if the user is confirming to proceed with generating design variations.
-
-Context: The system asked if the user wants to generate variations, and now we need to determine if their response is a confirmation.
-
-User intent analysis:
-- CONFIRM: Any affirmative response indicating they want to proceed
-- HOLD: Negative responses, requests for more changes, questions, or uncertainty
-
-Consider natural language patterns and context. The user may confirm in various ways beyond just "yes".
-
-Conversation context:
-${conversationHistory || ''}
-
-User response: "${content}"
-
-Respond with exactly one word: "CONFIRM" or "HOLD"`;
-      
-      const response = await this.openaiService.generateResponse(prompt);
-      return response.trim().toUpperCase() === 'CONFIRM';
-    } catch (error) {
-      return false;
-    }
-  }
-  private async wantsNewVariation(content: string): Promise<boolean> {
-    try {
-      const response = await this.openaiService.generateResponse(
-        `Analyze the user's message and determine their intent regarding design variations.
-
-        The user might want:
-        1. NEW VARIATION - They want to generate new/different design options (modifications, changes, improvements, or completely new variations)
-        2. SELECT/COMMENT - They are selecting from existing variations, commenting on current designs, or asking questions
-
-        Consider the context:
-        - Any request for changes, modifications, additions, or improvements = NEW VARIATION
-        - Any expression of wanting different options or alternatives = NEW VARIATION  
-        - Selecting specific variations (like "variation_1", "I like #2") = SELECT/COMMENT
-        - General comments without modification requests = SELECT/COMMENT
-
-        Respond with exactly one word: "NEW" or "SELECT"
-
-        User message: "${content}"`
-      );
-      return response.trim().toUpperCase().includes('NEW');
-    } catch (error) {
-      return false;
-    }
-  }
-  
-  private async detectDesignSelection(content: string): Promise<string | null> {
-    try {
-      const response = await this.openaiService.generateResponse(
-        `Analyze if the user is selecting/approving a specific design variation.
-
-        Look for:
-        - Explicit selections
-        - Approval phrases
-        - Clear preference statements indicating they want to proceed with a specific design
-
-        If they are selecting a design, respond with the variation number in format "variation_X" (where X is 1, 2, or 3).
-        If they are not selecting a specific design, respond with "NONE".
-
-        User message: "${content}"`
-      );
-      
-      const result = response.trim().toLowerCase();
-      if (result.includes('variation_')) {
-        return result.match(/variation_[123]/)?.[0] || null;
+      if (action === 'design:variation') {
+        const hasCredits = await this.creditService.hasEnoughCredits(userId, AIActionType.DESIGN_VARIATION);
+        const balance = await this.creditService.getBalance(userId);
+        if (!hasCredits) {
+          const msg = `You need credits to generate variations. Balance: ${balance}.`;
+          await this.streamChatService.sendAIMessage(dto.chatId, msg);
+          return { chatId: dto.chatId, state: 'design_preview', aiResponse: msg, insufficientCredits: true, creditBalance: balance };
+        }
+        await this.creditService.deductCredits(userId, AIActionType.DESIGN_VARIATION, dto.chatId);
+        const chatNow = await this.chatService.getChat(userId, dto.chatId);
+        const basePrompt = this.buildStructuredDesignPrompt(chatNow.metadata);
+        let result;
+        try {
+          result = await this.designWorkflowService.processDesignVariation(userId, dto.chatId, `${basePrompt} ${dto.content}`, chatNow.metadata?.preferredModel);
+        } catch (error) {
+          await this.creditService.refundCredits(userId, 1, 'Variation generation failed', dto.chatId);
+          throw error;
+        }
+        const newBalance = await this.creditService.getBalance(userId);
+        const reply = `New variations generated. Which do you prefer?\n\n💳 Credits remaining: ${newBalance}`;
+        await this.streamChatService.sendAIMessage(dto.chatId, reply);
+        return { chatId: dto.chatId, state: 'design_preview', designPreviews: result.designImages, aiResponse: reply, creditBalance: newBalance };
       }
-      return null;
+
+      if (action === 'design:select') {
+        const sel = (dto.content || '').trim().toLowerCase();
+        const valid = ['variation_1', 'variation_2', 'variation_3'];
+        if (!valid.includes(sel)) {
+          const reply = 'Please choose one of: variation_1, variation_2, variation_3.';
+          await this.streamChatService.sendAIMessage(dto.chatId, reply);
+          return { chatId: dto.chatId, state: 'design_preview', aiResponse: reply };
+        }
+        const chatNow = await this.chatService.getChat(userId, dto.chatId);
+        await this.chatService.updateChat(dto.chatId, { metadata: { ...chatNow.metadata, selectedVariety: sel } });
+        const reply = `Selected ${sel}. Provide approval details in JSON: {"name":"...","price":150,"quantity":1,"deadline":"YYYY-MM-DD"}`;
+        await this.streamChatService.sendAIMessage(dto.chatId, reply);
+        return { chatId: dto.chatId, state: 'design_preview', aiResponse: reply };
+      }
+
+      if (action === 'design:approve') {
+        const chatNow = await this.chatService.getChat(userId, dto.chatId);
+        const selectedVariety = (chatNow.metadata?.selectedVariety as string) || 'variation_1';
+        let payload: any = {};
+        try { payload = JSON.parse(dto.content || '{}'); } catch {}
+        const missing: string[] = [];
+        if (!payload.name) missing.push('name');
+        if (typeof payload.price !== 'number') missing.push('price');
+        if (typeof payload.quantity !== 'number') missing.push('quantity');
+        if (!payload.deadline) missing.push('deadline');
+        if (missing.length) {
+          const reply = `Missing fields: ${missing.join(', ')}. Example: {"name":"...","price":150,"quantity":1,"deadline":"2025-12-31"}`;
+          await this.streamChatService.sendAIMessage(dto.chatId, reply);
+          return { chatId: dto.chatId, state: chatNow.state, aiResponse: reply };
+        }
+        const result = await this.designWorkflowService.approveDesign(userId, {
+          chatId: dto.chatId,
+          selectedVariety: selectedVariety as any,
+          designName: payload.name,
+          price: payload.price,
+          collectionQuantity: payload.quantity,
+          deadline: new Date(payload.deadline),
+          description: payload.description,
+        });
+        const reply = `Design approved. Created DRAFT design: ${result.nft?.id}.`;
+        await this.streamChatService.sendAIMessage(dto.chatId, reply);
+        return { chatId: dto.chatId, state: ChatState.DESIGN_PREVIEW, aiResponse: reply, nft: result.nft };
+      }
+
+      if (action === 'design:publish') {
+        const reply = 'Ready to mint. Please provide transaction hash via action design:mint with content {"transactionHash":"0x..."}.';
+        await this.streamChatService.sendAIMessage(dto.chatId, reply);
+        return { chatId: dto.chatId, aiResponse: reply, web3Required: true };
+      }
+
+      if (action === 'design:mint') {
+        let payload: any = {};
+        try { payload = JSON.parse(dto.content || '{}'); } catch {}
+        const tx = payload.transactionHash;
+        if (!tx) {
+          const reply = 'Please send transactionHash: {"transactionHash":"0x..."}';
+          await this.streamChatService.sendAIMessage(dto.chatId, reply);
+          return { chatId: dto.chatId, aiResponse: reply };
+        }
+        const chatNow = await this.chatService.getChat(userId, dto.chatId);
+        if (!chatNow.nftId) {
+          const reply = 'No approved design found. Approve first with design:approve.';
+          await this.streamChatService.sendAIMessage(dto.chatId, reply);
+          return { chatId: dto.chatId, aiResponse: reply };
+        }
+        const nft = await this.designWorkflowService.mintAndPublishDesign(userId, chatNow.nftId, tx);
+        const reply = `Minted and published. NFT ${nft.id} is now live.`;
+        await this.streamChatService.sendAIMessage(dto.chatId, reply);
+        return { chatId: dto.chatId, aiResponse: reply, nft };
+      }
+
+    } catch (err) {
+      const msg = `Something went wrong: ${err?.message || 'unknown error'}`;
+      await this.streamChatService.sendAIMessage(dto.chatId, msg);
+      return { chatId: dto.chatId, aiResponse: msg };
+    }
+  }
+
+  // ─── AI helper: contextual response ───────────────────────────────────────
+  // Used for free-form responses outside the structured intake.
+  // Uses the unified system prompt from PromptService.
+  private async generateContextualResponse(
+    userMessage: string,
+    conversationHistory: string,
+    currentState: string,
+  ): Promise<string> {
+    const systemPrompt = this.promptService.getSystemPrompt();
+    const contextPrompt = `${systemPrompt}
+
+Current state: ${currentState}
+Conversation so far:
+${conversationHistory}
+
+User just said: "${userMessage}"
+
+Respond naturally. Keep it short — one or two sentences. Guide toward the next step.`;
+    try {
+      const response = await this.openaiService.generateResponse(contextPrompt);
+      return response.trim();
     } catch (error) {
+      return "I'm here! Tell me more about what you'd like to create.";
+    }
+  }
+
+  // ─── AI helper: detect fabric answer ──────────────────────────────────────
+  // Returns true (has fabric), false (no fabric), or null (unclear)
+  private async detectFabricAnswer(content: string): Promise<boolean | null> {
+    const lower = content.toLowerCase();
+
+    // Fast keyword check first — saves an API call for obvious answers
+    const yesWords = ['yes', 'yeah', 'yep', 'yup', 'i have', 'i do', 'got', 'have fabric', 'have a fabric'];
+    const noWords = ['no', 'nope', 'nah', 'don\'t have', 'no fabric', 'just an idea', 'just idea', 'idea only'];
+
+    if (yesWords.some((w) => lower.includes(w))) return true;
+    if (noWords.some((w) => lower.includes(w))) return false;
+
+    // Ambiguous — ask GPT-4o to decide
+    try {
+      const response = await this.openaiService.generateResponse(
+        `The user was asked "Do you have a fabric you'd like to use?"
+Their reply: "${content}"
+Do they have fabric? Reply with exactly one word: YES, NO, or UNCLEAR.`,
+      );
+      const r = response.trim().toUpperCase();
+      if (r === 'YES') return true;
+      if (r === 'NO') return false;
+      return null;
+    } catch {
       return null;
     }
   }
-  
-  private buildDesignPrompt(messages: ChatMessage[]): string {
-    const userMessages = messages.filter(msg => msg.role === 'user').map(msg => msg.content).join(' ');
-    return `Fashion design based on: ${userMessages}`;
+
+  // ─── AI helper: detect image in message ───────────────────────────────────
+  private async detectImageInMessage(content: string): Promise<boolean> {
+    // Check for common image-related phrases as a lightweight signal
+    const imageWords = ['uploaded', 'here it is', 'photo', 'image', 'picture', 'attached'];
+    return imageWords.some((w) => content.toLowerCase().includes(w));
   }
 
+  // ─── AI helper: describe fabric from photo ────────────────────────────────
+  // Called when a fabric photo is uploaded.
+  // In week 2 this will use gpt-image-2 vision to analyse the fabric.
+  // For week 1 it returns a placeholder description.
+  private async describeFabricFromPhoto(
+    content: string,
+    sketchData?: string,
+  ): Promise<string> {
+    if (!sketchData) {
+      return content || 'fabric (no description available)';
+    }
+
+    // WEEK 1 STUB — replace with real vision call in week 2
+    // Real implementation will send sketchData to OpenAI vision API and return
+    // a description like "deep emerald silk with natural sheen and fluid drape"
+    return 'your fabric';
+  }
+
+  // ─── AI helper: extract occasion info ────────────────────────────────────
+  private async extractOccasionInfo(
+    content: string,
+  ): Promise<{ occasion: string | null; eventDate: string | null; role: string | null }> {
+    try {
+      const response = await this.openaiService.generateResponse(
+        `Extract occasion information from this message.
+Message: "${content}"
+
+Reply in this exact JSON format (no markdown, no backticks):
+{"occasion":"wedding","eventDate":"2025-06-15","role":"guest"}
+
+- occasion: the type of event (wedding, prom, birthday, graduation, etc.) or null if unclear
+- eventDate: ISO date string if mentioned, or null
+- role: their role at the event (guest, bride, groom, etc.) or null
+
+JSON only:`,
+      );
+      try {
+        return JSON.parse(response.trim());
+      } catch {
+        return { occasion: content, eventDate: null, role: null };
+      }
+    } catch {
+      return { occasion: null, eventDate: null, role: null };
+    }
+  }
+
+  // ─── Helper: build style question ─────────────────────────────────────────
+  private buildStyleQuestion(occasion: string, fabricDescription?: string): string {
+    if (fabricDescription && fabricDescription !== 'your fabric') {
+      return `For a ${occasion} with ${fabricDescription} — are you thinking something fitted and structured, or flowing and relaxed? Or describe a look you love.`;
+    }
+    return `For your ${occasion} — are you thinking something fitted and structured, or flowing and relaxed? You can also describe a look you've seen and loved.`;
+  }
+
+  // ─── Helper: build structured design prompt ────────────────────────────────
+  // Replaces the old "join all messages into a blob" approach.
+  // Produces a structured prompt the image model can actually use.
+  private buildStructuredDesignPrompt(metadata: Record<string, any>): string {
+    const parts: string[] = [];
+
+    if (metadata?.occasion) parts.push(`Occasion: ${metadata.occasion}`);
+    if (metadata?.occasionRole) parts.push(`Role: ${metadata.occasionRole}`);
+    if (metadata?.fabricDescription) parts.push(`Fabric: ${metadata.fabricDescription}`);
+    if (metadata?.stylePreference) parts.push(`Style direction: ${metadata.stylePreference}`);
+    if (metadata?.eventDate) parts.push(`Event date: ${metadata.eventDate}`);
+
+    if (parts.length === 0) {
+      return 'Bespoke fashion design for a special occasion';
+    }
+
+    return `Bespoke fashion design. ${parts.join('. ')}.`;
+  }
+
+  // ─── Helper: extract sketch from messages ─────────────────────────────────
   private extractSketchFromMessages(messages: ChatMessage[]): string | null {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
-      if (message.metadata && message.metadata.sketchData) {
-        const base64 = message.metadata.sketchData.split(',')[1];
-        return base64;
+      if (message.metadata?.sketchData) {
+        return message.metadata.sketchData.split(',')[1];
       }
     }
     return null;
+  }
+
+  // ─── AI helper: is user confirming ────────────────────────────────────────
+  private async isUserConfirming(content: string): Promise<boolean> {
+    const lower = content.toLowerCase().trim();
+    const yesWords = ['yes', 'yeah', 'yep', 'yup', 'go ahead', 'do it', 'proceed', 'generate', 'sure', 'ok', 'okay', 'let\'s go'];
+    if (yesWords.some((w) => lower.includes(w))) return true;
+    if (lower.startsWith('no') || lower.includes('don\'t') || lower.includes('not yet')) return false;
+
+    try {
+      const response = await this.openaiService.generateResponse(
+        `Is the user confirming they want to proceed? Message: "${content}". Reply with exactly: CONFIRM or HOLD`,
+      );
+      return response.trim().toUpperCase() === 'CONFIRM';
+    } catch {
+      return false;
+    }
+  }
+
+  // ─── AI helper: wants new variation ───────────────────────────────────────
+  private async wantsNewVariation(content: string): Promise<boolean> {
+    try {
+      const response = await this.openaiService.generateResponse(
+        `Is the user asking for new/different design variations, or are they selecting/commenting on existing ones?
+Message: "${content}"
+Reply with exactly: NEW or SELECT`,
+      );
+      return response.trim().toUpperCase() === 'NEW';
+    } catch {
+      return false;
+    }
+  }
+
+  // ─── AI helper: detect design selection ───────────────────────────────────
+  private async detectDesignSelection(content: string): Promise<string | null> {
+    try {
+      const response = await this.openaiService.generateResponse(
+        `Is the user selecting a specific design variation?
+Message: "${content}"
+If yes, reply with the variation in format variation_1, variation_2, or variation_3.
+If no, reply with: NONE`,
+      );
+      const result = response.trim().toLowerCase();
+      return result.match(/variation_[123]/)?.[0] || null;
+    } catch {
+      return null;
+    }
   }
 }

--- a/src/ai-chat/services/prompt.service.ts
+++ b/src/ai-chat/services/prompt.service.ts
@@ -1,74 +1,223 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ChatState } from '../entities/chat.entity';
+
 @Injectable()
 export class PromptService {
   private readonly logger = new Logger(PromptService.name);
-  private readonly systemPrompt = `You are "Astra AI" – a polite, concise assistant guiding Creators and Makers
-through on-platform fashion production.
-Keep all coordination inside the chat.
-Mask phone numbers, emails, WhatsApp links or external payment requests.
-Use short paragraphs, title-case buttons, and emoji sparingly (max 1 per line).
-When a milestone action is required, always present a CLEAR button.`;
+
+  // ─── System prompt ────────────────────────────────────────────────────────
+  // This is Astra's core personality. Used by ALL AI calls.
+  // Previously ignored by openai.service.ts — that is a bug to fix separately.
+  private readonly systemPrompt = `You are "Astra AI" — a warm, knowledgeable fashion assistant helping people
+design bespoke outfits for special occasions and connecting them with skilled tailors to bring those designs to life.
+
+Your role:
+- Guide the user through designing their outfit step by step, one question at a time
+- Make recommendations that are culturally aware, occasion-appropriate, and fashion-forward
+- Keep all coordination on the platform — never share or accept external contact details or payment links
+- Be encouraging and specific — this is an exciting moment for the user
+
+Your tone:
+- Warm and conversational, like a knowledgeable friend in fashion
+- Concise — short paragraphs, never more than 3 sentences per response
+- Confident — make specific suggestions, don't be vague
+- Use one emoji per message maximum, only where it adds warmth
+
+Rules:
+- Never ask more than one question at a time
+- Never mention crypto, wallets, USDC, or blockchain — the user pays by card and that is all they need to know
+- Never generate designs before you know fabric status AND occasion
+- If a user shares a phone number, email, or external link — remove it and remind them to stay on platform
+- Any dispute or complaint — acknowledge it warmly and let them know the Astra team will step in`;
+
+  // ─── Creator prompts ───────────────────────────────────────────────────────
+  // One prompt per ChatState. Variables use {placeholder} syntax.
+  // replaceVariables() fills them in at call time.
+  // If a variable is missing, the raw {placeholder} shows — always check the
+  // calling code passes the right keys.
   private readonly creatorPrompts = {
-    [ChatState.WELCOME]: "Hey there 👋 Ready to design a custom outfit or launch a mini drop? • Upload a fabric pic **or** • Describe your look in one sentence.",
-    [ChatState.INTENT]: "Is this A) just for you, or B) something you'll sell to others? Reply *A* or *B*.",
-    [ChatState.INFO_GATHER]: "Great! • Event / vibe? • Deadline? • Budget idea?",
-    [ChatState.DESIGN_PREVIEW]: "Here's your design 🌟\nName: **{name}**\nSuggested Cost To Make: **${price}**\nETA: **{days} days**.",
-    [ChatState.DESIGN_APPROVED]: "Perfect! To list this on the marketplace, I need a few details:",
-    [ChatState.JOB_INFO_GATHER]: "Please provide:\n• Design name\n• Price per piece ($)\n• Number of pieces\n• Delivery location\n• Deadline",
-    [ChatState.PAYMENT_REQUIRED]: "Ready to list! Complete payment to publish your job.",
-    [ChatState.LISTED]: "All set! Makers will now apply. I'll ping you when proposals arrive.",
-    [ChatState.MAKER_PROPOSAL]: "🧵 **{makerName}** offered **${offer}** · **{turnaround} days** · Portfolio attached. Accept?",
-    [ChatState.ESCROW_PAYMENT]: "Pay **${offer}** into escrow to start. Funds release in 3 steps (15% / 40% / 30%).",
-    [ChatState.FABRIC_SHIPPING]: "Payment received . Please ship your fabric to: **{maskedAddress}** and send your measurements here.",
-    [ChatState.SAMPLE_REVIEW]: "Sample ready 👀 Approve to release 15%?",
-    [ChatState.FINAL_REVIEW]: "Final outfit looks great! Approve for shipping & release 40%?",
-    [ChatState.DELIVERY]: "📦 Delivered! Final 30% will release in 48h unless you report an issue.",
-    [ChatState.COMPLETED]: "Want to resell or re-drop this look? Type *Resell* anytime."
+
+    // WELCOME — first message every user sees. Fabric question is the fork.
+    [ChatState.WELCOME]:
+      `Hi! I'm Astra 👋 I help you design a bespoke outfit and find a skilled tailor to make it — for whatever occasion you have coming up.
+
+To get started: do you have a fabric you'd like to use?`,
+
+    // INTENT — replaced by fabric question above. Kept for fallback safety.
+    // TODO: remove once WELCOME → FABRIC_INTAKE flow is fully wired
+    [ChatState.INTENT]:
+      `Do you have a fabric you'd like to use for this outfit?`,
+
+    // INFO_GATHER — now split into sub-steps handled by the conversation logic.
+    // This is the fallback message if the state is reached without sub-step context.
+    [ChatState.INFO_GATHER]:
+      `Tell me about the occasion — what's the event, and when is it?`,
+
+    // DESIGN_PREVIEW — user sees their 3 designs for the first time.
+    // Variables: {occasion} — filled from metadata
+    [ChatState.DESIGN_PREVIEW]:
+      `Here are three designs for your {occasion} 🌟 Each one is different — take a look and tell me which feels most like you.`,
+
+    // DESIGN_APPROVED — user has picked a design. Bridge into measurements.
+    [ChatState.DESIGN_APPROVED]:
+      `Love that choice! To make sure it fits you perfectly, I'll need a few measurements. I'll guide you through each one — it only takes a few minutes. Ready?`,
+
+    // JOB_INFO_GATHER — collecting brief details before listing to tailors.
+    // Variables: {eventDate} — pre-filled from intake
+    [ChatState.JOB_INFO_GATHER]:
+      `Almost there. Your event is on {eventDate} so I'll match you with tailors who can finish comfortably in time. What's your rough budget for having this made?`,
+
+    // PAYMENT_REQUIRED — Creator is about to pay.
+    // Variables: {amount} — the tailor's quoted price
+    [ChatState.PAYMENT_REQUIRED]:
+      `Ready to get started! Pay {amount} securely to lock in your tailor. Your money is held safely and only released as the work progresses.`,
+
+    // LISTED — job is live, waiting for tailor bids.
+    [ChatState.LISTED]:
+      `Your brief is live! Tailors are reviewing it now. I'll let you know as soon as someone applies.`,
+
+    // MAKER_PROPOSAL — a tailor has bid. Creator needs to accept or decline.
+    // Variables: {makerName}, {offer}, {turnaround}
+    [ChatState.MAKER_PROPOSAL]:
+      `🧵 {makerName} has offered to make your outfit for {offer} — ready in {turnaround} days. Want to go with them?`,
+
+    // ESCROW_PAYMENT — explaining the milestone payment structure.
+    // Variables: {offer}
+    [ChatState.ESCROW_PAYMENT]:
+      `Your payment of {offer} will be held securely and released to the tailor in three stages as the work is completed — 30% when they start, 30% when you approve the progress, and 40% when it arrives and fits.`,
+
+    // FABRIC_SHIPPING — Creator needs to send their fabric (Path A only).
+    // Variables: {maskedAddress}
+    [ChatState.FABRIC_SHIPPING]:
+      `Payment received! Please post your fabric to {maskedAddress}. Once it's sent, share the tracking number and a photo here so we can get the tailor started.`,
+
+    // SAMPLE_REVIEW — tailor has uploaded a progress sample.
+    // Variables: {amount} — the actual dollar amount of 30% release
+    [ChatState.SAMPLE_REVIEW]:
+      `Your tailor has uploaded progress photos 👀 Take a look — does the fit and direction feel right? Approve to release the first payment ({amount}) and move to the final garment.`,
+
+    // FINAL_REVIEW — tailor has uploaded the finished garment.
+    // Variables: {amount} — the actual dollar amount of 30% release
+    [ChatState.FINAL_REVIEW]:
+      `Your tailor has uploaded the finished garment photos. Have a look — does everything look right? Approve to release payment ({amount}) and get it shipped to you.`,
+
+    // DELIVERY — garment is on its way.
+    // Variables: {deadline} — the 7-day window date
+    [ChatState.DELIVERY]:
+      `📦 Your outfit is on its way! Once it arrives, try it on and confirm it fits. If you haven't responded by {deadline}, the final payment will release automatically to your tailor.`,
+
+    // COMPLETED — the journey is done. Celebrate first, then next steps.
+    // Variables: {occasion}
+    [ChatState.COMPLETED]:
+      `Your outfit is with you — I hope you have the most amazing time at your {occasion} 🎉 Your measurements are saved so your next design will be even quicker. Whenever you're ready for something new, I'm here.`,
   };
+
+  // ─── Maker prompts ─────────────────────────────────────────────────────────
   private readonly makerPrompts = {
-    [ChatState.MAKER_PROPOSAL]: "🎉 You've been chosen for **{designName}** – budget **${offer}**. Fabric & measurements incoming. Three milestone payouts ahead!",
-    [ChatState.FABRIC_SHIPPING]: "Waiting on fabric for **{designName}**. Confirm once received to start clock.",
-    [ChatState.SAMPLE_REVIEW]: "Fabric received . Please upload a sample by **{sampleDue}**.",
-    [ChatState.FINAL_REVIEW]: "15% released 🎉. Finish garment and upload final photos by **{finalDue}**.",
-    [ChatState.DELIVERY]: "40% released . Ship outfit via tracked courier and add tracking number here.",
-    [ChatState.COMPLETED]: "Final 30% paid 💰. Great job! Your rating just improved."
+    [ChatState.MAKER_PROPOSAL]:
+      `🎉 You've been selected for {designName}. The Creator's measurements and design brief are attached. Three milestone payments ahead — first releases once fabric arrives and you begin.`,
+
+    [ChatState.FABRIC_SHIPPING]:
+      `Fabric for {designName} is on its way to you. Please confirm once it arrives so the Creator knows it's in safe hands.`,
+
+    [ChatState.SAMPLE_REVIEW]:
+      `Fabric received — first payment of {amount} has been released 🎉 Please upload your progress photos by {sampleDue} for the Creator to review.`,
+
+    [ChatState.FINAL_REVIEW]:
+      `Progress approved and second payment of {amount} released. Please finish the garment and upload final photos by {finalDue}.`,
+
+    [ChatState.DELIVERY]:
+      `Final garment approved — please ship via tracked courier and add the tracking number here. Third payment releases once the Creator confirms it fits.`,
+
+    [ChatState.COMPLETED]:
+      `Final payment of {amount} released 💰 Great work! Your rating has been updated.`,
   };
+
+  // ─── Quick action buttons ──────────────────────────────────────────────────
+  // Shown as tappable buttons in the UI at each state.
+  // Keep labels short — they appear as buttons on mobile.
   private readonly quickButtons = {
-    [ChatState.DESIGN_PREVIEW]: ["Approve Design", "Make Changes"],
-    [ChatState.PAYMENT_REQUIRED]: ["Complete Payment"],
-    [ChatState.MAKER_PROPOSAL]: ["Accept", "Decline"],
-    [ChatState.ESCROW_PAYMENT]: ["Pay Now"],
-    [ChatState.SAMPLE_REVIEW]: ["Approve Sample", "Ask Changes"],
-    [ChatState.FINAL_REVIEW]: ["Approve & Ship", "Ask Changes"],
-    [ChatState.DELIVERY]: ["Raise Issue"]
+    // Fabric question — the fork
+    [ChatState.WELCOME]: ['Yes, I have fabric', 'No, just an idea'],
+
+    // Design preview — pick or iterate
+    [ChatState.DESIGN_PREVIEW]: ['I love this one', 'Show me variations'],
+
+    // Payment gate
+    [ChatState.PAYMENT_REQUIRED]: ['Pay Now'],
+
+    // Tailor proposal — accept or see more
+    [ChatState.MAKER_PROPOSAL]: ['Accept', 'See other tailors'],
+
+    // Sample review — approve or request changes
+    [ChatState.SAMPLE_REVIEW]: ['Approve', 'Request Changes'],
+
+    // Final review — approve or request changes
+    [ChatState.FINAL_REVIEW]: ['Approve & Ship', 'Request Changes'],
+
+    // Delivery — confirm fit or raise issue
+    [ChatState.DELIVERY]: ['It fits perfectly', 'Raise an Issue'],
   };
+
+  // ─── Public methods ────────────────────────────────────────────────────────
+
   getSystemPrompt(): string {
     return this.systemPrompt;
   }
-  getPromptForState(state: ChatState, isCreator: boolean, variables: Record<string, any> = {}): string {
+
+  getPromptForState(
+    state: ChatState,
+    isCreator: boolean,
+    variables: Record<string, any> = {},
+  ): string {
     let prompt = '';
     if (isCreator) {
-      prompt = this.creatorPrompts[state] || "How can I help you with your fashion design today?";
+      prompt =
+        this.creatorPrompts[state] ||
+        'How can I help you with your design today?';
     } else {
-      prompt = this.makerPrompts[state] || "How can I help you with this project today?";
+      prompt =
+        this.makerPrompts[state] || 'How can I help you with this project?';
     }
     return this.replaceVariables(prompt, variables);
   }
+
   getQuickButtons(state: ChatState): string[] {
     return this.quickButtons[state] || [];
   }
-  private replaceVariables(text: string, variables: Record<string, any>): string {
+
+  // ─── Private helpers ───────────────────────────────────────────────────────
+
+  private replaceVariables(
+    text: string,
+    variables: Record<string, any>,
+  ): string {
     return text.replace(/\{([^}]+)\}/g, (match, key) => {
-      return variables[key] !== undefined ? variables[key] : match;
+      return variables[key] !== undefined ? String(variables[key]) : match;
     });
   }
+
+  // Strips contact details from user messages before the AI sees them.
+  // Runs on every incoming message in interactive-chat.service.ts.
   sanitizeUserMessage(message: string): string {
-    message = message.replace(/(\+\d{1,3}[\s-]?)?\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}/g, "<contact removed – please stay in Astra>");
-    message = message.replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g, "<contact removed – please stay in Astra>");
-    message = message.replace(/(https?:\/\/[^\s]+)/g, "<contact removed – please stay in Astra>");
-    if (message.includes("<contact removed")) {
-      message += "\n\nFor your safety and Buyer Protection, please keep all communication here.";
+    // Phone numbers
+    message = message.replace(
+      /(\+\d{1,3}[\s-]?)?\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}/g,
+      '<contact removed – please stay in Astra>',
+    );
+    // Email addresses
+    message = message.replace(
+      /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g,
+      '<contact removed – please stay in Astra>',
+    );
+    // URLs (WhatsApp links, external payment links, etc.)
+    message = message.replace(
+      /(https?:\/\/[^\s]+)/g,
+      '<contact removed – please stay in Astra>',
+    );
+    if (message.includes('<contact removed')) {
+      message +=
+        '\n\nFor your safety and Buyer Protection, please keep all communication here.';
     }
     return message;
   }


### PR DESCRIPTION
What this does:
- Rewrites the AI conversation to collect fabric status and occasion before generating anything
- Adds two paths: Path A (has fabric) and Path B (just an idea)
- One question at a time throughout intake
- Image generation is stubbed with placeholders for week 1

How to test:
- POST /ai-chat/start — should return new welcome message asking about fabric
- POST /ai-chat/message with "yes I have fabric" — should ask for photo
- Continue through the flow — occasion, style, then placeholder designs appear

Notes:
- Image generation stub to be replaced with gpt-image-2 in week 2